### PR TITLE
A couple of small fixes

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -169,17 +169,17 @@ function terraform-run() {
   if [[ "${APPLY_ONLY}" == false ]]; then
     echo "+++ :terraform: :buildkite: :hourglass: Running Terraform plan..."
 
+    set +e
     if [[ "${USE_WORKSPACES}" == true ]]; then
-      terraform-bin plan -input=false -out tfplan -var-file="${WORKSPACE}-terraform.tfvars"
+      terraform-bin plan -input=false -out tfplan -detailed-exitcode -var-file="${WORKSPACE}-terraform.tfvars"
     else
-      terraform-bin plan -input=false -out tfplan
+      terraform-bin plan -input=false -out tfplan -detailed-exitcode
     fi
+    TF_PLAN_EXIT_CODE=$?
+    set -x
 
-    # Capture plan output for setting variables and passing as artifacts.
-    terraform-bin show tfplan -no-color > tfplan.txt
-    terraform-bin show -json tfplan > tfplan.json
 
-    if grep -iFq "Plan: 0 to add, 0 to change, 0 to destroy." tfplan.txt; then
+    if [ $TF_PLAN_EXIT_CODE -eq 0 ]; then
       echo ""
       echo "--- :terraform: :buildkite: :white_check_mark: Exporting tf_diff=false to agent metadata."
       buildkite-agent meta-data set "tf_diff" "false"

--- a/hooks/command
+++ b/hooks/command
@@ -208,3 +208,5 @@ function terraform-run() {
 }
 
 terraform-run
+
+cd -


### PR DESCRIPTION
- Change back to original directory after plugin has done its business. Not having this was breaking the artifacts plugin for me - the upload/download paths were not matching
- Use terraform detailed exit code rather than parsing log output. The log output changed in https://github.com/hashicorp/terraform/commit/3c8a4e6e05afefb7639bf30efa852cf59f14ade6 (terraform version 1.1.0); the line being grepped for prior to this PR is no longer printed when there are no planned changes. `-detailed-exitcode` has been supported in terraform since https://github.com/hashicorp/terraform/pull/1355/commits/9a091ffa784e8149e94ac08d43e44e903d591e6b (terraform version 0.4.0)
